### PR TITLE
Fix issue with default unsigned char

### DIFF
--- a/xar/src/xar.c
+++ b/xar/src/xar.c
@@ -1934,7 +1934,8 @@ int main(int argc, char *argv[]) {
 	char *sig_path = NULL;
 	char *cert_path = NULL;
 	char *cert_CAfile = NULL;
-	char command = 0, c;
+	char command = 0;
+	int c;
 	char **args;
 	const char *argv0;
 	const char *tocfile = NULL;


### PR DESCRIPTION
For some reason on my distro, char defaults to unsigned,
which breaks getopts if it is returned to char.

I fixed it in the code by changing char to int; but I still slightly worry that
there might be an issue somewhere else.

Anyway changing char to int fixes this and is more "correct" as getopt returns int anyway.