### PR TITLE
xar_signature_add_x509certificate: handle cases where cert_data is null

### DIFF
--- a/xar/lib/signature.c
+++ b/xar/lib/signature.c
@@ -124,7 +124,7 @@ int32_t xar_signature_add_x509certificate(xar_signature_t sig, const uint8_t *ce
 {
 	struct __xar_x509cert_t *newcert;
 	
-	if( !sig )
+	if( !sig || !cert_data)
 		return -1;
 
 	newcert = malloc(sizeof(struct __xar_x509cert_t));


### PR DESCRIPTION
xar is segfaulting on my ARM64 systems (Mac M1, Raspberry Pi 4) 

#0  0x000000000024e470 in xar_signature_add_x509certificate (sig=0x23aef5d0, cert_data=0x0, cert_len=1149) at xar/xar/lib/signature.c:133

This PR modifies xar_signature_add_x509certificate to check that cert_data is not null before continuing with the signature.

