### PR TITLE
include stdlib.h to fix compilation

### DIFF
--- a/xar/lib/ext2.c
+++ b/xar/lib/ext2.c
@@ -41,6 +41,7 @@
 #include "asprintf.h"
 #endif
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include "xar.h"
 #include "arcmod.h"


### PR DESCRIPTION
hello ! Compilation fail for me, this fix it, thanks
```
lib/ext2.c:117:2: error: call to undeclared library function 'free' with type 'void (void *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        free(vstr);
        ^
lib/ext2.c:117:2: note: include the header <stdlib.h> or explicitly provide a declaration for 'free'
lib/ext2.c:198:13: error: call to undeclared library function 'strtol' with type 'long (const char *, char **, int)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                version = strtol(temp, NULL, 10);
                          ^
lib/ext2.c:198:13: note: include the header <stdlib.h> or explicitly provide a declaration for 'strtol'
2 errors generated.
make: *** [lib/Makefile.inc:200: lib/ext2.o] Error 1
make: *** Waiting for unfinished jobs....
```